### PR TITLE
issue-17 - handle code 3200 cleanly

### DIFF
--- a/weather.widget/index.coffee
+++ b/weather.widget/index.coffee
@@ -278,10 +278,10 @@ getOriginalIcon: (code) ->
 getYahooIcon: (code, dayOrNight) ->
   # Returns the image element from Yahoo with the proper image
   if code == '3200'
-    ''
-  else
-    imageURL = "http://l.yimg.com/a/i/us/nws/weather/gr/#{code}#{dayOrNight}.png"
-    '<img src="' + imageURL + '">'
+    # code 3200 translates to Yahoo's 44th weatherimage, an "NA"
+    code = 44
+  imageURL = "http://l.yimg.com/a/i/us/nws/weather/gr/#{code}#{dayOrNight}.png"
+  '<img src="' + imageURL + '">'
 
 dayMapping:
   0: 'Sunday'

--- a/weather.widget/index.coffee
+++ b/weather.widget/index.coffee
@@ -272,13 +272,16 @@ getIcon: (code, iconSet, dayOrNight) ->
     @getOriginalIcon(code)
 
 getOriginalIcon: (code) ->
-  return @iconMapping['unknown'] unless code
+  return @iconMapping['unknown'] unless code and code < 3200
   @iconMapping[code]
 
 getYahooIcon: (code, dayOrNight) ->
   # Returns the image element from Yahoo with the proper image
-  imageURL = "http://l.yimg.com/a/i/us/nws/weather/gr/#{code}#{dayOrNight}.png"
-  '<img src="' + imageURL + '">'
+  if code == '3200'
+    ''
+  else
+    imageURL = "http://l.yimg.com/a/i/us/nws/weather/gr/#{code}#{dayOrNight}.png"
+    '<img src="' + imageURL + '">'
 
 dayMapping:
   0: 'Sunday'


### PR DESCRIPTION
resolves issue #17 
- When a weather code 3200 is found, we shouldn't create an image. The
  Original style was showing the "Fair Weather" image, and Yahoo was
  showing an image with a broken URL. Now they both show nothing.
- Maybe it should show a "no image available" instead? Or create an
  empty span tag that users can customize as they wish?
