### PR TITLE
To Promises, fallback Location API, code reorganisation

### DIFF
--- a/weather.widget/.eslintrc.json
+++ b/weather.widget/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "env": {
+    "node": true,
+    "browser": true,
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react"
+  ],
+  "extends": ["standard", "eslint:recommended"]
+}

--- a/weather.widget/.gitignore
+++ b/weather.widget/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/weather.widget/get-weather
+++ b/weather.widget/get-weather
@@ -1,157 +1,106 @@
 // usage:
-// node get-weather.js [city] [region] [units] [lang] [geoipkey] [weatherapikey]
+// node get-weather.js [city] [region] [units] [lang] [static] [geoipApiKey] [geolocationApiKey] [forecastApiKey]
 
 // process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
 
 const query = require('querystring');
 const assert = require('assert');
 
-const options = {
-      city: process.argv[2],
-      region: process.argv[3],
-      units: process.argv[4].toLowerCase(),
-      lang: process.argv[5],
-      static: process.argv[6] === 'static',
-      geoipApiKey: process.argv[7],
-      geolocationApiKey: process.argv[8],
-      forecastApiKey: process.argv[9],
-      debug: process.argv[10] === 'debug'
+const OPTIONS = {
+  city: process.argv[2],
+  region: process.argv[3],
+  units: process.argv[4].toLowerCase(),
+  lang: process.argv[5],
+  static: process.argv[6] === 'static',
+  geoipApiKey: process.argv[7],
+  geolocationApiKey: process.argv[8],
+  forecastApiKey: process.argv[9],
 };
 
 const GEOIP_API = {
-  schemehostpath: "http://api.ipstack.com/check",
+  schemehostpath: 'http://api.ipstack.com/check',
   params: {
-    access_key : options.geoipApiKey,
-    language: "en",
-    output: "json"
-  }
-}
-const GEOLOCATION_API = {
-  schemehostpath: "https://api.opencagedata.com/geocode/v1/json",
-  params: {
-    q: options.city + "," + options.region,
-    key: options.geolocationApiKey,
-  }
-}
-const WEATHER_API = {
-  schemehostpath: "https://api.darksky.net/forecast/" + options.forecastApiKey + "/",  // + geo
-  params: {
-    units: options.units,
-    lang: options.lang,
-    exclude: "minutely,hourly,alerts,flags",
-  }
-}
+    access_key: OPTIONS.geoipApiKey,
+    language: 'en',
+    output: 'json',
+  },
+};
 
-const get = ({schemehostpath, params}) => {
+const GEOLOCATION_API = {
+  schemehostpath: 'https://api.opencagedata.com/geocode/v1/json',
+  params: {
+    q: `${OPTIONS.city},${OPTIONS.region}`,
+    key: OPTIONS.geolocationApiKey,
+  },
+};
+
+const WEATHER_API = {
+  schemehostpath: `https://api.darksky.net/forecast/${OPTIONS.forecastApiKey}/`,  // + geo
+  params: {
+    units: OPTIONS.units,
+    lang: OPTIONS.lang,
+    exclude: 'minutely,hourly,alerts,flags',
+  },
+};
+
+const get = ({ schemehostpath, params }) => {
   const querystring = query.stringify(params);
   const url = schemehostpath + (querystring ? '?' + querystring : '');
 
   return new Promise((resolve, reject) => {
     const lib = url.startsWith('https') ? require('https') : require('http');
-    if (options.debug) { console.log('get: ' + url + '\n') }  // TODO
-    const request = lib.get(url, (response) => {
+    const request = lib.get(url, response => {
       if (response.statusCode < 200 || response.statusCode > 299) {
-         reject(new Error('Failed to load page, status code: ' + response.statusCode + '\n' + response));
-       }
+        reject(new Error(
+          `Failed to load page, status code: ${response.statusCode}
+          ${response}`
+        ))
+      }
       const body = [];
-      response.on('data', (chunk) => body.push(chunk));
+      response.on('data', chunk => body.push(chunk));
       response.on('end', () => resolve(body.join('')));
     });
-    request.on('error', (err) => reject(err))
-    })
+    request.on('error', err => reject(err));
+  })
 };
 
-const wait = (duration) => {
-  return new Promise((resolve, reject) => {
-    setTimeout(resolve, duration)
-  })
-}
-
-
-const getGeoIP = () => {
+const getGeoIP = async () => {
   // {"ip":"50.242.117.125","type":"ipv4","continent_code":"NA","continent_name":"North America","country_code":"US","country_name":"United States","region_code":"CA","region_name":"California","city":"Union City","zip":"94587","latitude":37.589,"longitude":-122.0461,"location":{"geoname_id":5404555,"capital":"Washington D.C.","languages":[{"code":"en","name":"English","native":"English"}],"country_flag":"http:\/\/assets.ipstack.com\/flags\/us.svg","country_flag_emoji":"\ud83c\uddfa\ud83c\uddf8","country_flag_emoji_unicode":"U+1F1FA U+1F1F8","calling_code":"1","is_eu":false}}
-  return new Promise((resolve, reject) => {
-    if (options.static) {
-      resolve(options);
-    } else {
-      get(GEOIP_API)
-        .then(data => {
-          if (options.debug) {
-            console.log('getGeoIP');  // TODO
-            console.log(data);  // TODO
-            console.log(JSON.parse(data));  // TODO
-            console.log('---')  // TODO
-          }
-          const {city, region_name: region, location: {languages: [{code: lang}]}, latitude, longitude} = JSON.parse(data)
-          assert(city)
-          assert(region)
-          assert(lang)
-          assert(latitude)
-          assert(longitude)
-          resolve({city, region, lang, latitude, longitude});
-        })
-        .catch(err => { reject(err)  });
-    }
-  })
-}
+  return OPTIONS.static
+    ? OPTIONS
+    : get(GEOIP_API)
+      .then(data => {
+        const { city, region_name: region, location: { languages: [{ code: lang }] }, latitude, longitude } = JSON.parse(data);
+        return { city, region, lang, latitude, longitude };
+      })
+      .catch(e => { throw e });
+};
 
-const getGeoLocation = (err) => {
+const getGeoLocation = () => {
   // {"documentation":"https://opencagedata.com/api",...,"results":[{"annotations":{...},...,"formatted":"Carlton North VIC 3054, Australia","geometry":{"lat":-37.7845585,"lng":144.9728553}},...],"status":{"code":200,"message":"OK"},...,"thanks":"For using an OpenCage Data API","timestamp":{"created_http":"Wed, 06 Mar 2019 04:03:45 GMT","created_unix":1551845025},"total_results":2}
-  return new Promise((resolve, reject) => {
-    if (options.debug) { console.log('getGeoIP failed: ' + err) }
-    get(GEOLOCATION_API)
-      .then(data => {
-        if (options.debug) {
-          console.log('getGeoLocation');  // TODO
-          console.log(data);  // TODO
-          console.log(JSON.parse(data));  // TODO
-          console.log('---')  // TODO
-        }
-        const {results: [{ geometry: {lat: latitude, lng: longitude} }]} = JSON.parse(data)
-        const {city, region} = options
-        assert(city)
-        assert(region)
-        assert(latitude)
-        assert(longitude)
-        resolve({city, region, lang: 'en', latitude, longitude});
-      })
-      .catch(err => { reject(err)  });
-  })
-}
+  return get(GEOLOCATION_API)
+    .then(data => {
+      const { results: [{ geometry: { lat: latitude, lng: longitude } }] } = JSON.parse(data);
+      const { city, region } = OPTIONS;
+      return { city, region, lang: 'en', latitude, longitude };
+    })
+    .catch(e => { throw e });
+};
 
-const getWeather = ({city, region, lang, latitude, longitude}) => {
+const getWeather = ({ city, region, lang, latitude, longitude }) => {
   // {..,"currently":{"time":1551856440,"summary":"Overcast","icon":"cloudy",...},"daily":{...},"offset":-5}
-  return new Promise((resolve, reject) => {
-    const {schemehostpath, params} = WEATHER_API
-    get({schemehostpath: schemehostpath + latitude + ',' + longitude, params})
-      .then(data => {
-        if (options.debug) {
-          console.log('getWeather');  // TODO
-          console.log(data);  // TODO
-          console.log(Object.assign(JSON.parse(data), { location: city + ', ' + region }));  // TODO
-          console.log('---')  // TODO
-        }
-        const out = Object.assign(JSON.parse(data), { location: city + ', ' + region });
-        resolve(out);
-      })
-      .catch(err => { reject(err)  });
-  })
-}
+  const { schemehostpath, params } = WEATHER_API;
+  return get({ schemehostpath: `${schemehostpath}${latitude},${longitude}`, params })
+    .then(data => {
+      return { ...(JSON.parse(data)), location: `${city}, ${region}` }
+    })
+    .catch(e => { throw e });
+};
 
-const printResults = (json_data) => {
-  return new Promise((resolve, reject) => {
-    if (options.debug) { console.log('Final data:\n' + json_data + '\n' + 'Final output:') }
-    if (json_data) { 
-      console.log(JSON.stringify(json_data))
-      resolve()
-    } else {
-      reject('No data arrived!')
-    }
-  })
-}
+const printResults = json_data => console.log(JSON.stringify(json_data));
 
 getGeoIP()
   .catch(getGeoLocation)
   .then(getWeather)
   .then(printResults)
-  .catch(e => { console.log(e) })
+  .catch(e => console.log(e));

--- a/weather.widget/get-weather
+++ b/weather.widget/get-weather
@@ -4,7 +4,6 @@
 // process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
 
 const query = require('querystring');
-const assert = require('assert');
 
 const OPTIONS = {
   city: process.argv[2],
@@ -24,6 +23,11 @@ const GEOIP_API = {
     language: 'en',
     output: 'json',
   },
+  transform: data => {
+    // {"ip":"50.242.117.125","type":"ipv4","continent_code":"NA","continent_name":"North America","country_code":"US","country_name":"United States","region_code":"CA","region_name":"California","city":"Union City","zip":"94587","latitude":37.589,"longitude":-122.0461,"location":{"geoname_id":5404555,"capital":"Washington D.C.","languages":[{"code":"en","name":"English","native":"English"}],"country_flag":"http:\/\/assets.ipstack.com\/flags\/us.svg","country_flag_emoji":"\ud83c\uddfa\ud83c\uddf8","country_flag_emoji_unicode":"U+1F1FA U+1F1F8","calling_code":"1","is_eu":false}}
+    const { city, region_name: region, location: { languages: [{ code: lang }] }, latitude, longitude } = JSON.parse(data);
+    return { city, region, lang, latitude, longitude };
+  },
 };
 
 const GEOLOCATION_API = {
@@ -31,6 +35,12 @@ const GEOLOCATION_API = {
   params: {
     q: `${OPTIONS.city},${OPTIONS.region}`,
     key: OPTIONS.geolocationApiKey,
+  },
+  transform: data => {
+    // {"documentation":"https://opencagedata.com/api",...,"results":[{"annotations":{...},...,"formatted":"Carlton North VIC 3054, Australia","geometry":{"lat":-37.7845585,"lng":144.9728553}},...],"status":{"code":200,"message":"OK"},...,"thanks":"For using an OpenCage Data API","timestamp":{"created_http":"Wed, 06 Mar 2019 04:03:45 GMT","created_unix":1551845025},"total_results":2}
+    const { results: [{ geometry: { lat: latitude, lng: longitude } }] } = JSON.parse(data);
+    const { city, region } = OPTIONS;
+    return { city, region, lang: 'en', latitude, longitude };
   },
 };
 
@@ -50,54 +60,33 @@ const get = ({ schemehostpath, params }) => {
   return new Promise((resolve, reject) => {
     const lib = url.startsWith('https') ? require('https') : require('http');
     const request = lib.get(url, response => {
-      if (response.statusCode < 200 || response.statusCode > 299) {
-        reject(new Error(
-          `Failed to load page, status code: ${response.statusCode}
-          ${response}`
-        ))
-      }
-      const body = [];
-      response.on('data', chunk => body.push(chunk));
-      response.on('end', () => resolve(body.join('')));
+      let body = '';
+      response.on('data', chunk => body += chunk);
+      response.on('end', () => {
+        if (response.statusCode < 200 || response.statusCode > 299) {
+          reject(new Error(`Request failed: ${response.statusCode} ${response.statusMessage}
+${body}`));
+        }
+        else resolve(body);
+      })
     });
     request.on('error', err => reject(err));
-  })
+  });
 };
 
-const getGeoIP = async () => {
-  // {"ip":"50.242.117.125","type":"ipv4","continent_code":"NA","continent_name":"North America","country_code":"US","country_name":"United States","region_code":"CA","region_name":"California","city":"Union City","zip":"94587","latitude":37.589,"longitude":-122.0461,"location":{"geoname_id":5404555,"capital":"Washington D.C.","languages":[{"code":"en","name":"English","native":"English"}],"country_flag":"http:\/\/assets.ipstack.com\/flags\/us.svg","country_flag_emoji":"\ud83c\uddfa\ud83c\uddf8","country_flag_emoji_unicode":"U+1F1FA U+1F1F8","calling_code":"1","is_eu":false}}
-  return OPTIONS.static
-    ? OPTIONS
-    : get(GEOIP_API)
-      .then(data => {
-        const { city, region_name: region, location: { languages: [{ code: lang }] }, latitude, longitude } = JSON.parse(data);
-        return { city, region, lang, latitude, longitude };
-      })
-      .catch(e => { throw e });
-};
+const getGeoIP = async () => OPTIONS.static ? OPTIONS : GEOIP_API.transform(await get(GEOIP_API));
 
-const getGeoLocation = () => {
-  // {"documentation":"https://opencagedata.com/api",...,"results":[{"annotations":{...},...,"formatted":"Carlton North VIC 3054, Australia","geometry":{"lat":-37.7845585,"lng":144.9728553}},...],"status":{"code":200,"message":"OK"},...,"thanks":"For using an OpenCage Data API","timestamp":{"created_http":"Wed, 06 Mar 2019 04:03:45 GMT","created_unix":1551845025},"total_results":2}
-  return get(GEOLOCATION_API)
-    .then(data => {
-      const { results: [{ geometry: { lat: latitude, lng: longitude } }] } = JSON.parse(data);
-      const { city, region } = OPTIONS;
-      return { city, region, lang: 'en', latitude, longitude };
-    })
-    .catch(e => { throw e });
-};
+const getGeoLocation = async () => GEOLOCATION_API.transform(await get(GEOLOCATION_API))
 
-const getWeather = ({ city, region, lang, latitude, longitude }) => {
-  // {..,"currently":{"time":1551856440,"summary":"Overcast","icon":"cloudy",...},"daily":{...},"offset":-5}
+const getWeather = async ({ city, region, lang, latitude, longitude }) => {
   const { schemehostpath, params } = WEATHER_API;
-  return get({ schemehostpath: `${schemehostpath}${latitude},${longitude}`, params })
-    .then(data => {
-      return { ...(JSON.parse(data)), location: `${city}, ${region}` }
-    })
-    .catch(e => { throw e });
+  const data = await get({ schemehostpath: `${schemehostpath}${latitude},${longitude}`, params });
+
+  // {..,"currently":{"time":1551856440,"summary":"Overcast","icon":"cloudy",...},"daily":{...},"offset":-5}
+  return { ...(JSON.parse(data)), location: `${city}, ${region}` };
 };
 
-const printResults = json_data => console.log(JSON.stringify(json_data));
+const printResults = jsonData => console.log(JSON.stringify(jsonData));
 
 getGeoIP()
   .catch(getGeoLocation)

--- a/weather.widget/get-weather
+++ b/weather.widget/get-weather
@@ -1,128 +1,157 @@
 // usage:
 // node get-weather.js [city] [region] [units] [lang] [geoipkey] [weatherapikey]
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+// process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
 
-var http = require('http'),
-    https = require('https'),
-    query = require('querystring');
+const query = require('querystring');
+const assert = require('assert');
 
-var options = {
-    city: process.argv[2],
-    region: process.argv[3],
-    units: process.argv[4].toLowerCase(),
-    static: process.argv[5] === 'static',
-    lang: process.argv[6],
-    geoipApiKey: process.argv[7],
-    forecastApiKey: process.argv[8]
+const options = {
+      city: process.argv[2],
+      region: process.argv[3],
+      units: process.argv[4].toLowerCase(),
+      lang: process.argv[5],
+      static: process.argv[6] === 'static',
+      geoipApiKey: process.argv[7],
+      geolocationApiKey: process.argv[8],
+      forecastApiKey: process.argv[9],
+      debug: process.argv[10] === 'debug'
 };
 
-var weatherRetryCounter = 0;
-
-getLocation(function(location) {
-    if (location.city) {
-        options.region = location.region_name;
-        options.city = location.city;
-        options.latitude = location.latitude;
-        options.longitude = location.longitude;
-    }
-
-    getWeather(options, function(data) {
-        retryGetWeatherOrPrintResults(data);
-    });
-});
-
-function getLocation(callback) {
-    if (options.static) return callback({});
-
-    var url = "http://api.ipstack.com/check";
-    var params = {
-        access_key : options.geoipApiKey,
-        language : "en",
-        output: "json"
-    };
-
-    var request = getJSON(url, params, callback);
-
-    request.on('error', function() {
-        callback({})
-    });
-    setTimeout(function() {
-        request.abort();
-    }, 3000);
+const GEOIP_API = {
+  schemehostpath: "http://api.ipstack.com/check",
+  params: {
+    access_key : options.geoipApiKey,
+    language: "en",
+    output: "json"
+  }
+}
+const GEOLOCATION_API = {
+  schemehostpath: "https://api.opencagedata.com/geocode/v1/json",
+  params: {
+    q: options.city + "," + options.region,
+    key: options.geolocationApiKey,
+  }
+}
+const WEATHER_API = {
+  schemehostpath: "https://api.darksky.net/forecast/" + options.forecastApiKey + "/",  // + geo
+  params: {
+    units: options.units,
+    lang: options.lang,
+    exclude: "minutely,hourly,alerts,flags",
+  }
 }
 
-function printResults(data) {
-    data.location = options.city + ', ' + options.region;
-    console.log(JSON.stringify(data));
+const get = ({schemehostpath, params}) => {
+  const querystring = query.stringify(params);
+  const url = schemehostpath + (querystring ? '?' + querystring : '');
+
+  return new Promise((resolve, reject) => {
+    const lib = url.startsWith('https') ? require('https') : require('http');
+    if (options.debug) { console.log('get: ' + url + '\n') }  // TODO
+    const request = lib.get(url, (response) => {
+      if (response.statusCode < 200 || response.statusCode > 299) {
+         reject(new Error('Failed to load page, status code: ' + response.statusCode + '\n' + response));
+       }
+      const body = [];
+      response.on('data', (chunk) => body.push(chunk));
+      response.on('end', () => resolve(body.join('')));
+    });
+    request.on('error', (err) => reject(err))
+    })
+};
+
+const wait = (duration) => {
+  return new Promise((resolve, reject) => {
+    setTimeout(resolve, duration)
+  })
 }
 
-function retryGetWeatherOrPrintResults(data) {
-    var results = null;
-    try {
-        results = data.query.results;
-    } catch (ignore) { }
 
-    if (results == null && weatherRetryCounter < 5) {
-        weatherRetryCounter++;
-        getWeather(options, function(data) {
-            retryGetWeatherOrPrintResults(data);
-        });
+const getGeoIP = () => {
+  // {"ip":"50.242.117.125","type":"ipv4","continent_code":"NA","continent_name":"North America","country_code":"US","country_name":"United States","region_code":"CA","region_name":"California","city":"Union City","zip":"94587","latitude":37.589,"longitude":-122.0461,"location":{"geoname_id":5404555,"capital":"Washington D.C.","languages":[{"code":"en","name":"English","native":"English"}],"country_flag":"http:\/\/assets.ipstack.com\/flags\/us.svg","country_flag_emoji":"\ud83c\uddfa\ud83c\uddf8","country_flag_emoji_unicode":"U+1F1FA U+1F1F8","calling_code":"1","is_eu":false}}
+  return new Promise((resolve, reject) => {
+    if (options.static) {
+      resolve(options);
     } else {
-        printResults(data || {});
+      get(GEOIP_API)
+        .then(data => {
+          if (options.debug) {
+            console.log('getGeoIP');  // TODO
+            console.log(data);  // TODO
+            console.log(JSON.parse(data));  // TODO
+            console.log('---')  // TODO
+          }
+          const {city, region_name: region, location: {languages: [{code: lang}]}, latitude, longitude} = JSON.parse(data)
+          assert(city)
+          assert(region)
+          assert(lang)
+          assert(latitude)
+          assert(longitude)
+          resolve({city, region, lang, latitude, longitude});
+        })
+        .catch(err => { reject(err)  });
     }
+  })
 }
 
-function getWeather(options, callback) {
-    var geo = options.latitude + "," + options.longitude;
-    var exclude  = "minutely,hourly,alerts,flags";
-
-    var url = "https://api.darksky.net/forecast/" + options.forecastApiKey + "/" + geo;
-    var params = {
-        units : options.units,
-        lang: options.lang,
-        exclude: exclude
-    };
-
-    var request = getJSON(url, params, function(data) {
-        callback(data);
-    });
-
-    request.on('error', function(e) {
-        callback({
-            error: e.message
-        });
-    });
+const getGeoLocation = (err) => {
+  // {"documentation":"https://opencagedata.com/api",...,"results":[{"annotations":{...},...,"formatted":"Carlton North VIC 3054, Australia","geometry":{"lat":-37.7845585,"lng":144.9728553}},...],"status":{"code":200,"message":"OK"},...,"thanks":"For using an OpenCage Data API","timestamp":{"created_http":"Wed, 06 Mar 2019 04:03:45 GMT","created_unix":1551845025},"total_results":2}
+  return new Promise((resolve, reject) => {
+    if (options.debug) { console.log('getGeoIP failed: ' + err) }
+    get(GEOLOCATION_API)
+      .then(data => {
+        if (options.debug) {
+          console.log('getGeoLocation');  // TODO
+          console.log(data);  // TODO
+          console.log(JSON.parse(data));  // TODO
+          console.log('---')  // TODO
+        }
+        const {results: [{ geometry: {lat: latitude, lng: longitude} }]} = JSON.parse(data)
+        const {city, region} = options
+        assert(city)
+        assert(region)
+        assert(latitude)
+        assert(longitude)
+        resolve({city, region, lang: 'en', latitude, longitude});
+      })
+      .catch(err => { reject(err)  });
+  })
 }
 
-function getJSON(url, params, callback) {
-    if (arguments.length == 2) {
-        callback = params;
-        params = {};
+const getWeather = ({city, region, lang, latitude, longitude}) => {
+  // {..,"currently":{"time":1551856440,"summary":"Overcast","icon":"cloudy",...},"daily":{...},"offset":-5}
+  return new Promise((resolve, reject) => {
+    const {schemehostpath, params} = WEATHER_API
+    get({schemehostpath: schemehostpath + latitude + ',' + longitude, params})
+      .then(data => {
+        if (options.debug) {
+          console.log('getWeather');  // TODO
+          console.log(data);  // TODO
+          console.log(Object.assign(JSON.parse(data), { location: city + ', ' + region }));  // TODO
+          console.log('---')  // TODO
+        }
+        const out = Object.assign(JSON.parse(data), { location: city + ', ' + region });
+        resolve(out);
+      })
+      .catch(err => { reject(err)  });
+  })
+}
+
+const printResults = (json_data) => {
+  return new Promise((resolve, reject) => {
+    if (options.debug) { console.log('Final data:\n' + json_data + '\n' + 'Final output:') }
+    if (json_data) { 
+      console.log(JSON.stringify(json_data))
+      resolve()
+    } else {
+      reject('No data arrived!')
     }
-
-    var protocol = /^https:/.test(url) ? https : http,
-        querystring = query.stringify(params);
-
-    if (querystring)
-        url = url + '?' + querystring;
-
-    var json = "",
-        result;
-
-    return protocol.get(url, function(res) {
-        res.on('data', function(chunk) {
-            json += chunk;
-        });
-        res.on('end', function() {
-            try {
-                result = JSON.parse(json);
-            } catch (e) {
-                result = {
-                    error: e.message
-                };
-            }
-            callback(result);
-        });
-    });
+  })
 }
+
+getGeoIP()
+  .catch(getGeoLocation)
+  .then(getWeather)
+  .then(printResults)
+  .catch(e => { console.log(e) })

--- a/weather.widget/get-weather
+++ b/weather.widget/get-weather
@@ -1,8 +1,6 @@
 // usage:
 // node get-weather.js [city] [region] [units] [lang] [static] [geoipApiKey] [geolocationApiKey] [forecastApiKey]
 
-// process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-
 const query = require('querystring');
 
 const OPTIONS = {
@@ -17,18 +15,28 @@ const OPTIONS = {
 };
 
 const GEOIP_API = {
-  schemehostpath: 'http://api.ipstack.com/check',
-  params: {
-    access_key: OPTIONS.geoipApiKey,
-    language: 'en',
-    output: 'json',
-  },
-  transform: data => {
-    // {"ip":"50.242.117.125","type":"ipv4","continent_code":"NA","continent_name":"North America","country_code":"US","country_name":"United States","region_code":"CA","region_name":"California","city":"Union City","zip":"94587","latitude":37.589,"longitude":-122.0461,"location":{"geoname_id":5404555,"capital":"Washington D.C.","languages":[{"code":"en","name":"English","native":"English"}],"country_flag":"http:\/\/assets.ipstack.com\/flags\/us.svg","country_flag_emoji":"\ud83c\uddfa\ud83c\uddf8","country_flag_emoji_unicode":"U+1F1FA U+1F1F8","calling_code":"1","is_eu":false}}
-    const { city, region_name: region, location: { languages: [{ code: lang }] }, latitude, longitude } = JSON.parse(data);
-    return { city, region, lang, latitude, longitude };
+  schemehostpath: 'http://ip-api.com/json/',
+  params: {},
+  transform: (data) => {
+    // {..."city":"Berkeley",...,"lat":37.8664,"lon":-122.257,...,"regionName":"California",...}
+    const { city, region, lat: latitude, lon: longitude } = JSON.parse(data);
+    return { city, region, lang: 'en', latitude, longitude };
   },
 };
+
+// const GEOIP_API = {
+//   schemehostpath: 'http://api.ipstack.com/check',
+//   params: {
+//     access_key: OPTIONS.geoipApiKey,
+//     language: 'en',
+//     output: 'json',
+//   },
+//   transform: data => {
+//     // {"ip":"50.242.117.125",...,"region_name":"California","city":"Union City",...,"latitude":37.589,"longitude":-122.0461,"location":{...,"languages":[{"code":"en",...}]...}}
+//     const { city, region_name: region, location: { languages: [{ code: lang }] }, latitude, longitude } = JSON.parse(data);
+//     return { city, region, lang, latitude, longitude };
+//   },
+// };
 
 const GEOLOCATION_API = {
   schemehostpath: 'https://api.opencagedata.com/geocode/v1/json',
@@ -37,7 +45,7 @@ const GEOLOCATION_API = {
     key: OPTIONS.geolocationApiKey,
   },
   transform: data => {
-    // {"documentation":"https://opencagedata.com/api",...,"results":[{"annotations":{...},...,"formatted":"Carlton North VIC 3054, Australia","geometry":{"lat":-37.7845585,"lng":144.9728553}},...],"status":{"code":200,"message":"OK"},...,"thanks":"For using an OpenCage Data API","timestamp":{"created_http":"Wed, 06 Mar 2019 04:03:45 GMT","created_unix":1551845025},"total_results":2}
+    // {"documentation":"https://opencagedata.com/api",...,"results":[{...,"geometry":{"lat":-37.7845585,"lng":144.9728553}},...],...,"thanks":"For using an OpenCage Data API",...}
     const { results: [{ geometry: { lat: latitude, lng: longitude } }] } = JSON.parse(data);
     const { city, region } = OPTIONS;
     return { city, region, lang: 'en', latitude, longitude };
@@ -51,6 +59,10 @@ const WEATHER_API = {
     lang: OPTIONS.lang,
     exclude: 'minutely,hourly,alerts,flags',
   },
+  transform: (data, city, region) => {
+    // {..,"currently":{"time":1551856440,"summary":"Overcast","icon":"cloudy",...},"daily":{...},"offset":-5}
+    return { ...(JSON.parse(data)), location: `${city}, ${region}` };
+  }
 };
 
 const get = ({ schemehostpath, params }) => {
@@ -64,8 +76,8 @@ const get = ({ schemehostpath, params }) => {
       response.on('data', chunk => body += chunk);
       response.on('end', () => {
         if (response.statusCode < 200 || response.statusCode > 299) {
-          reject(new Error(`Request failed: ${response.statusCode} ${response.statusMessage}
-${body}`));
+          reject(new Error((`Request failed: ${response.statusCode} ${response.statusMessage}
+                            ${body}`).replace(/^ {2,}/gm,'')));
         }
         else resolve(body);
       })
@@ -82,8 +94,7 @@ const getWeather = async ({ city, region, lang, latitude, longitude }) => {
   const { schemehostpath, params } = WEATHER_API;
   const data = await get({ schemehostpath: `${schemehostpath}${latitude},${longitude}`, params });
 
-  // {..,"currently":{"time":1551856440,"summary":"Overcast","icon":"cloudy",...},"daily":{...},"offset":-5}
-  return { ...(JSON.parse(data)), location: `${city}, ${region}` };
+  return WEATHER_API.transform(data, city, region)
 };
 
 const printResults = jsonData => console.log(JSON.stringify(jsonData));

--- a/weather.widget/index.coffee
+++ b/weather.widget/index.coffee
@@ -1,8 +1,6 @@
 options =
   city          : 'Melbourne'       # default city in case location detection fails
   region        : 'Victoria'        # default region in case location detection fails
-  # latitude      : '-37.784559'      # default latitude in case location detection fails
-  # longitude     : '144.972855'      # default longitude in case location detection fails
   units         : 'si'              # si for celcius. us for Fahrenheit
   lang          : 'en'              # set language code for the current day summary
   useLocation   : 'auto'            # set to 'static' to disable automatic location lookup
@@ -20,7 +18,7 @@ appearance =
   showWeatherText: true             # set to true to show the text label for the weather
   showForecast  : true              # set to true to show the 5 day forecast
 
-refreshFrequency: 600000            # Update every 10 minutes
+refreshFrequency: 1800000            # Update every 30 minutes
 
 style: """
   bottom : 20px

--- a/weather.widget/index.coffee
+++ b/weather.widget/index.coffee
@@ -1,11 +1,14 @@
 options =
-  city          : "Troy"       # default city in case location detection fails
-  region        : "NY"              # default region in case location detection fails
-  units         : 'us'              # si for celcius. us for Fahrenheit
-  useLocation   : 'auto'            # set to 'static' to disable automatic location lookup
+  city          : 'Melbourne'       # default city in case location detection fails
+  region        : 'Victoria'        # default region in case location detection fails
+  # latitude      : '-37.784559'      # default latitude in case location detection fails
+  # longitude     : '144.972855'      # default longitude in case location detection fails
+  units         : 'si'              # si for celcius. us for Fahrenheit
   lang          : 'en'              # set language code for the current day summary
-  geoipApiKey   : 'REPLACE_WITH_YOUR_API_KEY'  # https://ipstack.com/
-  weatherApiKey : 'REPLACE_WITH_YOUR_API_KEY'  # https://darksky.net/dev
+  useLocation   : 'auto'            # set to 'static' to disable automatic location lookup
+  geoipApiKey   : '$(security find-generic-password -a ubersicht -s ipstack -w)'  # https://ipstack.com/
+  geolocationApiKey : '$(security find-generic-password -a ubersicht -s OpenCageData -w)'  # https://darksky.net/dev
+  weatherApiKey : '$(security find-generic-password -a ubersicht -s DarkSkyWeather -w)'  # https://darksky.net/dev
 
 appearance =
   iconSet       : 'original'        # "original" for the original icons, or "yahoo" for yahoo icons
@@ -20,8 +23,8 @@ appearance =
 refreshFrequency: 600000            # Update every 10 minutes
 
 style: """
-  top  : 10px
-  right : 150px
+  bottom : 20px
+  right : 300px
   width: #{appearance.baseFontSize * 8.57}px
 
   font-family: Helvetica Neue
@@ -156,9 +159,10 @@ command: "#{process.argv[0]} weather.widget/get-weather \
                             \"#{options.city}\" \
                             \"#{options.region}\" \
                             #{options.units} \
-                            #{options.useLocation}
-                            #{options.lang}
-                            #{options.geoipApiKey}
+                            #{options.lang} \
+                            #{options.useLocation} \
+                            #{options.geoipApiKey} \
+                            #{options.geolocationApiKey} \
                             #{options.weatherApiKey}"
 
 appearance: appearance
@@ -185,6 +189,7 @@ render: -> """
 """
 
 update: (output, domEl) ->
+
   @$domEl = $(domEl)
 
   channel = JSON.parse(output)


### PR DESCRIPTION
A handful of changes:

1. Move API configuration into a config object for each API service ((nearly) all of the logic relating to each service in one place (I didn't find an elegant way to avoid concatenating the lat/long onto the URL for the weather service)).
2. Add a fallback Location service (I'm not sure if the static location option is working for you; it wasn't working for me without lat/long, so I've added a service to look those up from the city/region).
3. Use Promises (which I find much easier to follow that callback hell).

Then a handful more that you're much more likely to decide not to include:

4. Prefer using the keychain over hardcoding plaintext secrets into code (`$(security find-generic-password -a ubersicht -s ipstack -w)` pulls a secret from the keychain; see https://www.netmeister.org/blog/keychain-passwords.html for more context and how to put the secret into your keychain in the first place).
5. Replace ipstack.com with ip-api.com (which doesn't require an account, and which gives me much more accurate geolocation).

Then some stuff you totally should not include, my tweaks to local my config, but that I am selfishly not going to remove since it's in my `master` and it would be extra work.